### PR TITLE
Improve mod index fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ Integrate `mod_menu.lua` into a Balatro modding environment that supports
 ImGui and LuaSocket. Call `ModMenu.fetch_index()` on startup and render the UI
 via `ModMenu.draw()`.
 
+`ModMenu.fetch_index()` will attempt to download the index specified by
+`ModMenu.index_url`. If that fails, it falls back to loading the local
+`mod_index.json` that ships with this repository.
+
 The exact integration steps depend on the loader (SteamODD/Lovely) used by
 Balatro. See the comments in `mod_menu.lua` for details.
 


### PR DESCRIPTION
## Summary
- add optional local index file when remote is unavailable
- document the new fallback behaviour in README

## Testing
- `luac -p src/mod_menu.lua`

------
https://chatgpt.com/codex/tasks/task_e_688666ef0e108332a144074b00e20465