### PR TITLE
Improve integration instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,32 @@ Integrate `mod_menu.lua` into a Balatro modding environment that supports
 ImGui and LuaSocket. Call `ModMenu.fetch_index()` on startup and render the UI
 via `ModMenu.draw()`.
 
+`ModMenu.fetch_index()` will attempt to download the index specified by
+`ModMenu.index_url`. If that fails, it falls back to loading the local
+`mod_index.json` that ships with this repository.
+
+The local index file is looked up relative to the directory containing
+`mod_menu.lua`, so you can package it alongside the script when integrating
+with your mod loader.
+
 The exact integration steps depend on the loader (SteamODD/Lovely) used by
 Balatro. See the comments in `mod_menu.lua` for details.
+
+### Lovely integration example
+
+For Lovely-based loaders you can create a `lovely.toml` manifest to inject the
+script early during startup:
+
+```toml
+[manifest]
+version = "1.0.0"
+priority = 0
+
+[[patches]]
+module = { source = "src/mod_menu.lua", before = "main.lua" }
+```
+
+Add another patch to insert a button into `functions/UI_definitions.lua` next to
+the "Collection" button. When the button is pressed call `ModMenu.toggle()` and
+invoke `ModMenu.draw()` each frame so the window can appear.
 

--- a/lovely.toml
+++ b/lovely.toml
@@ -1,0 +1,6 @@
+[manifest]
+version = "1.0.0"
+priority = 0
+
+[[patches]]
+module = { source = "src/mod_menu.lua", before = "main.lua" }

--- a/src/mod_menu.lua
+++ b/src/mod_menu.lua
@@ -21,11 +21,23 @@ ModMenu.mods_path = 'Mods'
 -- URL of remote index listing available mods
 ModMenu.index_url = 'https://example.com/balatro/mod_index.json'
 
+-- optional local fallback index file
+-- default path is relative to this script's location
+local script_dir = (debug.getinfo(1, 'S').source:gsub('^@', '')):match('(.*/)' ) or './'
+ModMenu.index_file = script_dir .. 'mod_index.json'
+
 -- table populated with data from mod_index.json
 ModMenu.available_mods = {}
 
 -- table of installed mods with version info
 ModMenu.installed_mods = {}
+
+-- whether the UI window is currently visible
+ModMenu.visible = false
+
+function ModMenu.toggle()
+    ModMenu.visible = not ModMenu.visible
+end
 
 ------------------------------------------------------
 -- Utility functions
@@ -42,22 +54,38 @@ local function run_git_command(cmd)
     return result == 0
 end
 
+local function load_index_file(path)
+    if not file_exists(path) then
+        return nil, 'index file not found: ' .. path
+    end
+    local f = io.open(path, 'r')
+    local contents = f:read('*a')
+    f:close()
+    local index, pos, err = json.decode(contents, 1, nil)
+    if err then
+        return nil, 'failed to parse index file: ' .. err
+    end
+    ModMenu.available_mods = index.mods or {}
+    return true
+end
+
 ------------------------------------------------------
 -- Index fetching and installed mod scanning
 ------------------------------------------------------
 
 -- Download mod_index.json from the internet
 function ModMenu.fetch_index()
-    local body, status = socket_http.request(ModMenu.index_url)
-    if not body or status ~= 200 then
-        return nil, 'failed to fetch index: HTTP ' .. tostring(status)
+    if ModMenu.index_url and ModMenu.index_url ~= '' then
+        local body, status = socket_http.request(ModMenu.index_url)
+        if body and status == 200 then
+            local index, pos, err = json.decode(body, 1, nil)
+            if not err then
+                ModMenu.available_mods = index.mods or {}
+                return true
+            end
+        end
     end
-    local index, pos, err = json.decode(body, 1, nil)
-    if err then
-        return nil, 'failed to parse index: ' .. err
-    end
-    ModMenu.available_mods = index.mods or {}
-    return true
+    return load_index_file(ModMenu.index_file)
 end
 
 -- Scan Mods folder for installed mods and read mod.json
@@ -109,6 +137,7 @@ end
 ------------------------------------------------------
 
 function ModMenu.draw()
+    if not ModMenu.visible then return end
     if imgui.Begin('Balatro Mod Menu') then
         if imgui.Button('Refresh Mod List') then
             ModMenu.fetch_index()


### PR DESCRIPTION
## Summary
- add `ModMenu.visible` toggle so the UI can be shown/hidden at runtime
- document a basic Lovely manifest for loading the script
- include `lovely.toml` example in the repo
- fix TOML syntax for the manifest

## Testing
- `luac -p src/mod_menu.lua`


------
https://chatgpt.com/codex/tasks/task_e_688666ef0e108332a144074b00e20465